### PR TITLE
Allow b32-encoded object keys

### DIFF
--- a/lib/tjson/object.rb
+++ b/lib/tjson/object.rb
@@ -4,7 +4,7 @@ module TJSON
   # TJSON object type (i.e. hash/dict-alike)
   class Object < ::Hash
     def []=(name, value)
-      unless name.start_with?("s:", "b16:", "b64:")
+      unless name.start_with?("s:", "b16:", "b32:", "b64:")
         raise TJSON::ParseError, "invalid tag on object name: #{name[/\A(.*?):/, 1]}" if name.include?(":")
         raise TJSON::ParseError, "no tag found on object name: #{name.inspect}"
       end


### PR DESCRIPTION
The example object in the [base32 section of the RFC](https://www.tjson.org/spec/#base32-b32) implies that binary object keys should be allowed as base32, in addition to base64 and hex.