### PR TITLE
Add fractional second support to timestamps

### DIFF
--- a/lib/tjson/datatype/timestamp.rb
+++ b/lib/tjson/datatype/timestamp.rb
@@ -10,7 +10,9 @@ module TJSON
 
       def convert(str)
         raise TJSON::TypeError, "expected String, got #{str.class}: #{str.inspect}" unless str.is_a?(::String)
-        raise TJSON::ParseError, "invalid timestamp: #{str.inspect}" unless str =~ /\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\z/
+        unless str =~ /\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z\z/
+          raise TJSON::ParseError, "invalid timestamp: #{str.inspect}"
+        end
 
         ::Time.iso8601(str)
       end

--- a/spec/tjson/datatype/timestamp_spec.rb
+++ b/spec/tjson/datatype/timestamp_spec.rb
@@ -16,4 +16,20 @@ RSpec.describe TJSON::DataType::Timestamp do
       expect { subject.convert(invalid_timestamp) }.to raise_error(TJSON::ParseError)
     end
   end
+
+  context "valid UTC RFC3339 timestamp with fractional seconds" do
+    let(:example_timestamp) { "2016-10-02T07:31:51.42Z" }
+
+    it "parses successfully" do
+      expect(subject.convert(example_timestamp)).to be_a Time
+    end
+  end
+
+  context "valid UTC RFC3339 timestamp with comma separated fractional seconds" do
+    let(:invalid_timestamp) { "2016-10-02T07:31:51,42Z" }
+
+    it "raises TJSON::ParseError" do
+      expect { subject.convert(invalid_timestamp) }.to raise_error(TJSON::ParseError)
+    end
+  end
 end


### PR DESCRIPTION
RFC-3339 supports fractional seconds as does the ISO-8601 but the regexp being used for validation of timestamp strings did not support it.

Technically the [RFC-3339 specification](https://www.ietf.org/rfc/rfc3339.txt) allows use of a comma `,` as well as decimal point `.` for the whole and fractional seconds separator:

>  time-fraction     = ("," / ".") 1*DIGIT

Although use of `,` is common in European countries, in the interests of eliminating equivalent but lexically different encodings which would have a different cryptographic hash, this change only allows the decimal point as separator.  Thus `2016-10-02T07:31:51.42Z` is a valid timestamp, but `2016-10-02T07:31:51,42Z` is not.