### PR TITLE
rubocop.yml: Run rubocop in a separate build step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ before_install: gem install bundler
 
 bundler_args: --without development doc
 
+script: bundle exec rake ci
+
 rvm:
   - jruby-9.1.5.0
   - 2.0
@@ -14,6 +16,10 @@ rvm:
 
 matrix:
   fast_finish: true
+  include:
+  # Only run RuboCop on the latest Ruby
+  - env: SUITE="rubocop"
+    rvm: 2.4.1
 
 branches:
   only:

--- a/Rakefile
+++ b/Rakefile
@@ -9,3 +9,8 @@ require "rubocop/rake_task"
 RuboCop::RakeTask.new
 
 task default: %w[spec rubocop]
+
+case ENV["SUITE"]
+when "rubocop" then task ci: %w[rubocop]
+else task ci: %w[spec]
+end


### PR DESCRIPTION
More parallelism! We don't need to run RuboCop on every Ruby under the sun.